### PR TITLE
Add versioning, pushing releases to github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  aws-cli: circleci/aws-cli@0.1.13
-
 executors:
   linuxgo:
     working_directory: /go/src/github.com/honeycombio/buildevents
@@ -30,14 +27,7 @@ jobs:
     steps:
       - attach_workspace:
           at: workspace
-      - aws-cli/install
-      - aws-cli/configure:
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
-      # push to both versioned spot and "latest" download
-      - run: aws s3 cp workspace/buildevents s3://honeycomb-builds/honeycombio/buildevents/${CIRCLE_BUILD_NUM}/buildevents
-      - run: aws s3 cp workspace/buildevents s3://honeycomb-builds/honeycombio/buildevents/latest/buildevents
+      - # stub for pushing github release
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}+${CIRCLE_SHA1}" ./...
       - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
-      - run: find artifacts -ls
+      - run: ls -al artifacts
       - persist_to_workspace:
           root: artifacts
           paths:
@@ -29,7 +29,7 @@ jobs:
     steps:
       - attach_workspace:
           at: artifacts
-      - run: find artifacts -ls
+      - run: ls -al artifacts
       - run:
           name: "Publish Release on GitHub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - checkout
       - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}+${CIRCLE_SHA1}" ./...
-      - run: mkdir artifacts; cp $GOPATH/bin/buildevents artifacts/
+      - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
       - persist_to_workspace:
           root: artifacts
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,23 +11,28 @@ jobs:
     executor: linuxgo
     steps:
       - checkout
-      - go test -v ./...
+      - run: go test -v ./...
   build:
     executor: linuxgo
     steps:
       - checkout
-      - run: go install ./...
-      - run: mkdir workspace; cp $GOPATH/bin/buildevents workspace/
+      - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}+${CIRCLE_SHA1}" ./...
+      - run: mkdir artifacts; cp $GOPATH/bin/buildevents artifacts/
       - persist_to_workspace:
-          root: workspace
+          root: artifacts
           paths:
             - buildevents
   publish:
-    executor: linuxgo
+    docker:
+      - image: cibuilds/github:0.12.1
     steps:
       - attach_workspace:
-          at: workspace
-      - # stub for pushing github release
+          at: artifacts
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            VERSION=$(artifacts/buildevents --version)
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} ./artifacts/
 
 workflows:
   build:
@@ -40,5 +45,5 @@ workflows:
           requires:
             - build
           filters:
-            branches:
-              only: master
+            tags:
+              only: /^v\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - checkout
       - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}+${CIRCLE_SHA1}" ./...
       - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
+      - run: find artifacts -ls
       - persist_to_workspace:
           root: artifacts
           paths:
@@ -28,6 +29,7 @@ jobs:
     steps:
       - attach_workspace:
           at: artifacts
+      - run: find artifacts -ls
       - run:
           name: "Publish Release on GitHub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
       - checkout
       - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}+${CIRCLE_SHA1}" ./...
       - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
-      - run: ls -al artifacts
       - persist_to_workspace:
           root: artifacts
           paths:
@@ -29,12 +28,10 @@ jobs:
     steps:
       - attach_workspace:
           at: artifacts
-      - run: ls -al artifacts
       - run:
           name: "Publish Release on GitHub"
           command: |
-            VERSION=$(artifacts/buildevents --version)
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} ./artifacts/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,14 @@ workflows:
       - build:
           requires:
             - test
+          filters:
+            tags:
+              only: /.*/
       - publish:
           requires:
             - build
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  aws-cli: circleci/aws-cli@0.1.13
+
 executors:
   linuxgo:
     working_directory: /go/src/github.com/honeycombio/buildevents
@@ -27,7 +30,14 @@ jobs:
     steps:
       - attach_workspace:
           at: workspace
-      - # stub for pushing github release
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      # push to both versioned spot and "latest" download
+      - run: aws s3 cp workspace/buildevents s3://honeycomb-builds/honeycombio/buildevents/${CIRCLE_BUILD_NUM}/buildevents
+      - run: aws s3 cp workspace/buildevents s3://honeycomb-builds/honeycombio/buildevents/latest/buildevents
 
 workflows:
   build:

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 	"github.com/honeycombio/libhoney-go/transmission"
 )
 
+// Version will be set by CircleCI based on a git tag and the commit hash
+var Version string
+
 // buildevents expects to get some unchanging values from the environment and
 // the rest as positional arguments on the command line.
 //
@@ -219,6 +222,17 @@ func main() {
 		libhoney.Init(libhoney.Config{
 			Transmission: &transmission.DiscardSender{},
 		})
+	}
+
+	if Version == "" {
+		Version = "dev"
+	}
+	libhoney.AddField("meta.version", Version)
+
+	// respond to ./buildevents --version in order to enable circleci to tag releases
+	if os.Args[1] == "--version" {
+		fmt.Println(Version)
+		os.Exit(0)
 	}
 
 	if len(os.Args) < 4 {


### PR DESCRIPTION
* updates the circle build script to push build artifact to github as releases when building a tagged version
* adds a `--version` flag to the binary, set by the github tag and commit hash