### PR TITLE
Fix small typo in Circle CI example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
     steps:
       - attach_workspace:
           at: buildevents
-      - run |
+      - run: |
           BUILD_START=$(cat buildevents/build_start)
           buildevents build $CIRCLE_WORKFLOW_ID $BUILD_START success
 ```


### PR DESCRIPTION
Adds a missing colon after run in the Circle CI example and avoid a schema error when Circle CI processes the config file.