### PR TITLE
Fix *one more* run | typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ jobs:
     steps:
       - attach_workspace:
           at: buildevents
-      - run |
+      - run: |
           BUILD_START=$(cat buildevents/build_start)
           buildevents build $CIRCLE_WORKFLOW_ID $BUILD_START success
 


### PR DESCRIPTION
I missed another identical typo! See https://github.com/honeycombio/buildevents/pull/7 for part one of this exciting series.