### PR TITLE
send the buildevents version to Honeyocmb in the useragent field

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,23 @@ func main() {
 	if apihost == "" {
 		apihost = "https://api.honeycomb.io"
 	}
+	if Version == "" {
+		Version = "dev"
+	}
 
+	// respond to ./buildevents --version
+	if os.Args[1] == "--version" {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
+	if len(os.Args) < 4 {
+		usage()
+		os.Exit(1)
+	}
+
+	// initialize libhoney
+	libhoney.UserAgentAddition = fmt.Sprintf("buildevents/%s", Version)
 	if apikey != "" {
 		libhoney.Init(libhoney.Config{
 			WriteKey: apikey,
@@ -223,22 +239,7 @@ func main() {
 			Transmission: &transmission.DiscardSender{},
 		})
 	}
-
-	if Version == "" {
-		Version = "dev"
-	}
 	libhoney.AddField("meta.version", Version)
-
-	// respond to ./buildevents --version in order to enable circleci to tag releases
-	if os.Args[1] == "--version" {
-		fmt.Println(Version)
-		os.Exit(0)
-	}
-
-	if len(os.Args) < 4 {
-		usage()
-		os.Exit(1)
-	}
 
 	spanType := os.Args[1]
 	traceID := os.Args[2]


### PR DESCRIPTION
To be good libhoney citizens, let's decorate the user agent field to say that we're running buildevents and pass along what version is in use.

The only real change here is adding `libhoney.UserAgentAddition` - the rest is just moving a few functions around so if we're going to early exit with a usage doc we don't bother initializing libhoney first.