### PR TITLE
Build macOS binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,27 @@ executors:
     docker:
       - image: circleci/golang:1.10
 
+commands:
+  go-build:
+    parameters:
+      os:
+        description: Target operating system
+        type: enum
+        enum: ["linux", "darwin"]
+        default: "linux"
+      arch:
+        description: Target architecture
+        type: enum
+        enum: ["386", "amd64"]
+        default: "amd64"
+    steps:
+      - run: |
+          GOOS=<< parameters.os >> \
+          GOARCH=<< parameters.arch >> \
+          go build -ldflags "-X main.Version=${CIRCLE_TAG}" \
+          -o $GOPATH/bin/buildevents-<< parameters.os >>-<< parameters.arch >> \
+          ./...
+
 jobs:
   test:
     executor: linuxgo
@@ -16,12 +37,20 @@ jobs:
     executor: linuxgo
     steps:
       - checkout
-      - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
-      - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
+      - go-build:
+          os: linux
+          arch: "386"
+      - go-build:
+          os: linux
+          arch: amd64
+      - go-build:
+          os: darwin
+          arch: amd64
+      - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents-* artifacts/
       - persist_to_workspace:
           root: artifacts
           paths:
-            - buildevents
+            - buildevents-*
   publish:
     docker:
       - image: cibuilds/github:0.12.1

--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@ If you have a working go environment in your build, the easiest way to install `
 go get github.com/honeycombio/buildevents/
 ```
 
-There is also a built binary (for linux) hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab. The following two commands will down load and make executable the github-hosted binary.
+There are also built binaries for linux and macOS hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab. The following two commands will down load and make executable the github-hosted binary.
+
+**linux:**
+
 ```
-curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-linux-amd64
+chmod 755 buildevents
+```
+
+**macOS:**
+
+```
+curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-darwin-amd64
 chmod 755 buildevents
 ```
 


### PR DESCRIPTION
Use $GOOS and $GOARCH parameters to build binaries for multiple platforms.

In theory, we could build binaries for Windows using the same approach as introduced in this PR, but I don't have immediate access to verify the binary. You can test this by invoking `go-build` with `arch: windows`.

My experience with Go tooling is pretty limited. Feedback appreciated!

# Test Plan

```
$ circleci config validate
Config file at .circleci/config.yml is valid.
```

Verified binaries generated by [Circle CI in my fork](https://circleci.com/gh/hramos/buildevents/42#artifacts/containers/0).

On macOS:

```
$ uname && uname -m
Darwin
x86_64

$ curl -L -o buildevents https://42-187978966-gh.circle-artifacts.com/0/bin/buildevents-darwin-amd64
$ chmod 755 buildevents
$ ./buildevents cmd
Usage: buildevents [build,step,cmd] ... args

        For documentation, see https://github.com/honeycombio/buildevents

$ ./buildevents --version
dev
```

On linux:

```
$ uname && uname --m
Linux
x86_64

$ curl -o buildevents -L https://42-187978966-gh.circle-artifacts.com/0/bin/buildevents-linux-amd64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 7499k    0 7499k    0     0  5152k      0 --:--:--  0:00:01 --:--:-- 5154k
$ chmod 755 buildevents 
$ ./buildevents cmd
Usage: buildevents [build,step,cmd] ... args

	For documentation, see https://github.com/honeycombio/buildevents
$ ./buildevents --version
dev
```

Notes: 

* I did not test the 386 variant on linux.
* The publish step is only executed on tagged commits. That code path has not been tested. According to the docs, [`ghr` supports specifying a directory](https://github.com/tcnksm/ghr#usage), so I expect it to publish all binaries. The `persist_to_workspace` command already filters out files that do not match the `buildevents-*` glob, so it should be safe to publish the entire artifacts directory.