### PR TITLE
Instrument the buildevents build with buildevents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           steps:
             - checkout
             - buildevents/berun:
-                bename: go test
+                bename: "go test"
                 becommand: go test -v ./...
   build:
     executor: linuxgo
@@ -30,7 +30,7 @@ jobs:
           steps:
             - checkout
             - buildevents/berun:
-                bename: go install
+                bename: "go install"
                 becommand: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
             - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           steps:
             - checkout
             - buildevents/berun:
-                bename: "go test"
+                bename: \"go test\"
                 becommand: go test -v ./...
   build:
     executor: linuxgo
@@ -30,7 +30,7 @@ jobs:
           steps:
             - checkout
             - buildevents/berun:
-                bename: "go install"
+                bename: \"go install\"
                 becommand: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
             - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           steps:
             - checkout
             - buildevents/berun:
-                bename: \"go test\"
+                bename: go_test
                 becommand: go test -v ./...
   build:
     executor: linuxgo
@@ -30,7 +30,7 @@ jobs:
           steps:
             - checkout
             - buildevents/berun:
-                bename: \"go install\"
+                bename: go_install
                 becommand: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
             - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - buildevents/with_job_span:
           steps:
             - checkout
+            ## method 1 to send a command span
             ## buildevent/berun is a circleci friendly way to create a buildevents command span
             - buildevents/berun:
                 bename: go_test
@@ -30,6 +31,7 @@ jobs:
       - buildevents/with_job_span:
           steps:
             - checkout
+            ## method 2 to send a command span
             ## the raw buildevents binary is also available in the $PATH but requires more arguments
             - run: buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID go_install -- go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,8 @@ workflows:
             tags:
               only: /.*/
       - test:
+          requires:
+            - setup
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  buildevents: honeycombio/buildevents@0.0.2
+
 executors:
   linuxgo:
     working_directory: /go/src/github.com/honeycombio/buildevents
@@ -7,21 +10,33 @@ executors:
       - image: circleci/golang:1.10
 
 jobs:
+  setup:
+    executor: linuxgo
+    steps:
+      - buildevents/start_trace
   test:
     executor: linuxgo
     steps:
-      - checkout
-      - run: go test -v ./...
+      - buildevents/with_job_span:
+          steps:
+            - checkout
+            - buildevents/berun:
+                bename: go test
+                becommand: go test -v ./...
   build:
     executor: linuxgo
     steps:
-      - checkout
-      - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
-      - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
-      - persist_to_workspace:
-          root: artifacts
-          paths:
-            - buildevents
+      - buildevents/with_job_span:
+          steps:
+            - checkout
+            - buildevents/berun:
+                bename: go install
+                becommand: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
+            - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
+            - persist_to_workspace:
+                root: artifacts
+                paths:
+                  - buildevents
   publish:
     docker:
       - image: cibuilds/github:0.12.1
@@ -32,10 +47,19 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents
+  final:
+    executor: linuxgo
+    steps:
+      - buildevents/finish_trace:
+          result: success
 
 workflows:
   build:
     jobs:
+      - setup:
+          filters:
+            tags:
+              only: /.*/
       - test:
           filters:
             tags:
@@ -54,3 +78,10 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - final:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - buildevents/with_job_span:
           steps:
             - checkout
+            ## buildevent/berun is a circleci friendly way to create a buildevents command span
             - buildevents/berun:
                 bename: go_test
                 becommand: go test -v ./...
@@ -29,9 +30,8 @@ jobs:
       - buildevents/with_job_span:
           steps:
             - checkout
-            - buildevents/berun:
-                bename: go_install
-                becommand: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
+            ## the raw buildevents binary is also available in the $PATH but requires more arguments
+            - run: buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID go_install -- go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
             - persist_to_workspace:
                 root: artifacts


### PR DESCRIPTION
Add instrumentation to the build config that builds buildevents using the buildevents orb. A little chicken/egg here, but now that there are released versions of the buildevents orb it should be fine.

Addresses Issue #12 