### PR TITLE
when the circle poll times out, fail the build

### DIFF
--- a/circleapi.go
+++ b/circleapi.go
@@ -110,6 +110,9 @@ func pollCircleAPI(traceID, teamName, apiHost, dataset string, timeoutMin int) e
 	sendTraceRoot(name, traceID, buildStatus, startTime, time.Since(startTime))
 	printTraceURL(traceID, teamName, apiHost, dataset, startTime.Unix())
 
+	if failed {
+		return fmt.Errorf("failed build due to timing out polling after %d minutes", timeoutMin)
+	}
 	return nil
 }
 


### PR DESCRIPTION
It's odd to indicate in the trace that the build has failed because we timed out without the build actually failing. And yet it's also odd for the instrumentation to fail the build when it wouldn't otherwise fail. I can't decide which behavior is worse. Anybody have an opinion? If the poll times out and declares the trace has failed, should it fail the build too?