### PR TITLE
pass in the circleci api token when appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ CirclecI requires use of the CircleCI API to detect when workflows start and sto
 
 The `watch` command polls the CircleCI API and waits until all jobs have finished (either succeeded, failed, or are blocked). It then reports the final status of the build with the appropriate timers.  `watch` should be invoked in a job all on its own, dependent on only the `setup` job, with only the Trace ID to use. After some time, `watch` will timeout waiting for the build to finish and fail. The timeout default is 10 minutes and can be overridden by setting `BUILDEVENT_TIMEOUT`
 
+For public github repositories and public CircleCI builds, it is ok to call the CircleCI API with no authentication token. However, to use `watch` with a private github repo, you will need to provide a CircleCI API token to `buildevents` via the `BUILDEVENT_CIRCLE_API_TOKEN` environment variable. You can get a personal API token from https://circleci.com/account/api. For more detail on tokens, please see the [CircleCI API Tokens documentation](https://circleci.com/docs/2.0/managing-api-tokens/)
+
 The `watch` command will emit a link to the finished trace to the job output in Honeycomb when the build is complete.
 
 ```yaml

--- a/circleapi.go
+++ b/circleapi.go
@@ -16,7 +16,13 @@ import (
 func pollCircleAPI(traceID, teamName, apiHost, dataset string, timeoutMin int) error {
 	workflowID, _ := os.LookupEnv("CIRCLE_WORKFLOW_ID")
 	thisJobName, _ := os.LookupEnv("CIRCLE_JOB")
-	client := &circleci.Client{}
+
+	// TODO decide whether we can exist without token set. it's not required for
+	// public repos; it is for private repos.
+	token, _ := os.LookupEnv("BUILDEVENT_CIRCLE_API_TOKEN")
+	client := &circleci.Client{
+		Token: token,
+	}
 
 	wfJobs, err := getJobs(client, workflowID)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -322,6 +322,7 @@ func main() {
 
 	// if the command we ran exitted with an error, let's exit with the same error
 	if err != nil {
+		fmt.Printf("buildevents - Error detected: %s\n", err.Error())
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 				os.Exit(status.ExitStatus())


### PR DESCRIPTION
get a circleci token from the environment to enable private builds.

If the token is absent and the repo does not allow public access, the error you will get says:

```
buildevents - Error detected: 404: Workflow not found
Exited with code 1
```

For public repos, the API calls will work with or without a token.