### PR TITLE
provide better error messages when polling fails

### DIFF
--- a/circleapi.go
+++ b/circleapi.go
@@ -107,6 +107,9 @@ func pollCircleAPI(traceID, teamName, apiHost, dataset string, timeoutMin int) e
 
 	// if one of our jobs has failed, mark the build as failed. Otherwise success!
 	wf, err := client.GetWorkflowV2(workflowID)
+	if err != nil {
+		return err
+	}
 	startTime := wf.CreatedAt
 	buildStatus := "success"
 	if failed {


### PR DESCRIPTION
If polling against circleci fails for some reason, this at least passes along the error message that caused the failure.