### PR TITLE
add the ci provider to the user-agent field for Honeycomb analysis

### DIFF
--- a/main.go
+++ b/main.go
@@ -297,6 +297,7 @@ func main() {
 
 	if ciProvider != "" {
 		libhoney.AddField("ci_provider", ciProvider)
+		libhoney.UserAgentAddition += fmt.Sprintf(" (%s)", ciProvider)
 	}
 	libhoney.AddField("trace.trace_id", traceID)
 


### PR DESCRIPTION
The buildevents user-agent field currently contains the version of libhoney and the version of buidevents used. This change adds the CI provider to help us gauge how much effort to put in to compatibility with each provider.