### PR TITLE
trim spaces around incoming positional arguments

### DIFF
--- a/cmd_build.go
+++ b/cmd_build.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,9 +23,9 @@ a URL pointing to the generated trace in Honeycomb to STDOUT.`,
 		Args:                  argOptions(2, "success", "failure"),
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			traceID := args[0]
-			startTime := parseUnix(args[1])
-			outcome := args[2]
+			traceID := strings.TrimSpace(args[0])
+			startTime := parseUnix(strings.TrimSpace(args[1]))
+			outcome := strings.TrimSpace(args[2])
 
 			ev := createEvent(cfg, *ciProvider, traceID)
 			defer ev.Send()
@@ -58,14 +59,14 @@ func argOptions(pos int, opts ...string) cobra.PositionalArgs {
 		cobra.MinimumNArgs(pos+1),
 		func(cmd *cobra.Command, args []string) error {
 			for _, opt := range opts {
-				if args[pos] == opt {
+				if strings.TrimSpace(args[pos]) == opt {
 					return nil
 				}
 			}
 			if len(opts) == 1 {
-				return fmt.Errorf("argument at index %d (%q) must be %q", pos, args[pos], opts[0])
+				return fmt.Errorf("argument at index %d (%q) must be %q", pos, strings.TrimSpace(args[pos]), opts[0])
 			}
-			return fmt.Errorf("argument at index %d (%q) must be one of %v", pos, args[pos], opts)
+			return fmt.Errorf("argument at index %d (%q) must be one of %v", pos, strings.TrimSpace(args[pos]), opts)
 		},
 	)
 }

--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -36,9 +36,9 @@ will be launched via "bash -c" using "exec".`,
 		),
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			traceID := args[0]
-			stepID := args[1]
-			name := args[2]
+			traceID := strings.TrimSpace(args[0])
+			stepID := strings.TrimSpace(args[1])
+			name := strings.TrimSpace(args[2])
 
 			var quoted []string
 			for _, s := range args[3:] {

--- a/cmd_step.go
+++ b/cmd_step.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -20,10 +21,10 @@ most closely maps to a single job. It should be run at the end of the step.`,
 		Args:                  cobra.ExactArgs(4),
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			traceID := args[0]
-			stepID := args[1]
-			startTime := parseUnix(args[2])
-			name := args[3]
+			traceID := strings.TrimSpace(args[0])
+			stepID := strings.TrimSpace(args[1])
+			startTime := parseUnix(strings.TrimSpace(args[2]))
+			name := strings.TrimSpace(args[3])
 
 			ev := createEvent(cfg, *ciProvider, traceID)
 			defer ev.Send()

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	circleci "github.com/jszwedko/go-circleci"
@@ -39,7 +40,7 @@ build with the appropriate timers.`,
 			},
 		),
 		Run: func(cmd *cobra.Command, args []string) {
-			traceID := args[0]
+			traceID := strings.TrimSpace(args[0])
 
 			ev := createEvent(cfg, *ciProvider, traceID)
 			defer ev.Send()


### PR DESCRIPTION
This was a regression in the refactor to Cobra - spaces around things like the trace ID cause trace hierarchy to break. All of the positional arguments should lose any whitespace that occurs before or after the argument.