### PR TITLE
require multiple passes before declaring victory. adding output

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ CirclecI requires use of the CircleCI API to detect when workflows start and sto
 
 The `watch` command polls the CircleCI API and waits until all jobs have finished (either succeeded, failed, or are blocked). It then reports the final status of the build with the appropriate timers.  `watch` should be invoked in a job all on its own, dependent on only the `setup` job, with only the Trace ID to use. After some time, `watch` will timeout waiting for the build to finish and fail. The timeout default is 10 minutes and can be overridden by setting `BUILDEVENT_TIMEOUT`
 
-Using the `watch` requires a personal (not project) CircleCI API token. You can provide this token to `buildevents` via the `BUILDEVENT_CIRCLE_API_TOKEN` environment variable. You can get a personal API token from https://circleci.com/account/api. For more detail on tokens, please see the [CircleCI API Tokens documentation](https://circleci.com/docs/2.0/managing-api-tokens/)
+Using the `watch` command requires a personal (not project) CircleCI API token. You can provide this token to `buildevents` via the `BUILDEVENT_CIRCLE_API_TOKEN` environment variable. You can get a personal API token from https://circleci.com/account/api. For more detail on tokens, please see the [CircleCI API Tokens documentation](https://circleci.com/docs/2.0/managing-api-tokens/)
 
 The `watch` command will emit a link to the finished trace to the job output in Honeycomb when the build is complete.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ CirclecI requires use of the CircleCI API to detect when workflows start and sto
 
 The `watch` command polls the CircleCI API and waits until all jobs have finished (either succeeded, failed, or are blocked). It then reports the final status of the build with the appropriate timers.  `watch` should be invoked in a job all on its own, dependent on only the `setup` job, with only the Trace ID to use. After some time, `watch` will timeout waiting for the build to finish and fail. The timeout default is 10 minutes and can be overridden by setting `BUILDEVENT_TIMEOUT`
 
-For public github repositories and public CircleCI builds, it is ok to call the CircleCI API with no authentication token. However, to use `watch` with a private github repo, you will need to provide a CircleCI API token to `buildevents` via the `BUILDEVENT_CIRCLE_API_TOKEN` environment variable. You can get a personal API token from https://circleci.com/account/api. For more detail on tokens, please see the [CircleCI API Tokens documentation](https://circleci.com/docs/2.0/managing-api-tokens/)
+Using the `watch` requires a personal (not project) CircleCI API token. You can provide this token to `buildevents` via the `BUILDEVENT_CIRCLE_API_TOKEN` environment variable. You can get a personal API token from https://circleci.com/account/api. For more detail on tokens, please see the [CircleCI API Tokens documentation](https://circleci.com/docs/2.0/managing-api-tokens/)
 
 The `watch` command will emit a link to the finished trace to the job output in Honeycomb when the build is complete.
 

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -173,7 +173,7 @@ func waitCircle(parent context.Context, cfg watchConfig) (bool, time.Time, error
 					fmt.Printf("Build failed!\n")
 					return
 				}
-				// yay loks like maybe we're done?
+				// yay looks like maybe we're done?
 				fmt.Printf("Build appears finished; checking %d more times to make sure.\n", checksLeft)
 				continue
 			}

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -143,7 +143,7 @@ func waitCircle(parent context.Context, cfg watchConfig) (bool, time.Time, error
 			// check for timeout or pause before the next iteration
 			select {
 			case <-ctx.Done():
-				fmt.Fprintf(os.Stderr, "Timeout reached waiting for the workflow to finish")
+				fmt.Fprintf(os.Stderr, "Timeout reached waiting for the workflow to finish\n")
 				return
 			default:
 			}

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -214,6 +214,8 @@ func evalWorkflow(client *circleci.Client, wfID string, jobName string) (finishe
 			// it's waiting on a running job or
 			// it's not configured to run this build (because of a tag or something)
 			continue
+		case "queued":
+			return false, failed, nil
 		case "failed":
 			failed = true
 			continue

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -201,7 +201,7 @@ func evalWorkflow(client *circleci.Client, wfID string, jobName string) (finishe
 		fmt.Printf("error polling: %s\n", err.Error())
 		return true, true, err
 	}
-	fmt.Printf(summarizeJobList(wfJobs) + "\n")
+	fmt.Println(summarizeJobList(wfJobs))
 
 	for _, job := range wfJobs {
 		// always count ourself as finished so we don't wait for ourself

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -138,8 +138,8 @@ func waitCircle(parent context.Context, cfg watchConfig) (bool, time.Time, error
 
 	go func() {
 		defer close(done)
-		tk := time.NewTicker(5 * time.Second)
-		for range <-tk.C {
+		tk := time.NewTicker(5 * time.Second).C
+		for range tk {
 			// check for timeout or pause before the next iteration
 			select {
 			case <-ctx.Done():

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -134,7 +134,7 @@ func waitCircle(parent context.Context, cfg watchConfig) (bool, time.Time, error
 	// In that case there are no jobs running and some jobs blocked that could
 	// still run. If we think the build has passed and finished, let's give it a
 	// buffer to spin up new jobs before really considering it done.
-	checksLeft := numChecks
+	checksLeft := numChecks + 1 // +1 because we decrement at the beginning of the loop
 
 	go func() {
 		defer close(done)
@@ -143,6 +143,7 @@ func waitCircle(parent context.Context, cfg watchConfig) (bool, time.Time, error
 			// check for timeout or pause before the next iteration
 			select {
 			case <-ctx.Done():
+				// TODO add the fact that it timed out to the trace to say why it failed
 				fmt.Fprintf(os.Stderr, "Timeout reached waiting for the workflow to finish\n")
 				return
 			default:

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -150,6 +150,7 @@ func waitCircle(parent context.Context, cfg watchConfig) (bool, time.Time, error
 
 			finished, failed, err := evalWorkflow(client, cfg.workflowID, cfg.jobName)
 			if finished {
+				checksLeft--
 				if checksLeft <= 0 {
 					// we're done checking.
 					passed = !failed
@@ -160,7 +161,6 @@ func waitCircle(parent context.Context, cfg watchConfig) (bool, time.Time, error
 					}
 					return
 				}
-				checksLeft--
 				if err != nil {
 					// we previously successfully queried for the workflow; this is likely a
 					// transient error


### PR DESCRIPTION
When a CircleCI workflow is configured to run jobs serially, there can be some delay between when one job finishes and the next begins. If you poll the API at just the right point in between one finishing and the next starting, it's possible to get a reply that might otherwise convince you that all jobs are finished (either succeeded or blocked). 
This change will not treat that state as being definitive but will ask the API a few more times to confirm that in fact all jobs are finished and there isn't one just waiting to start. If it finds that the previous check was in fact misleading and there _are_ more jobs to run, it will reset the retry counter until the next time. 
This will extend the total time of the build by 15sec or so, which seems an acceptable delay.

Here's an example of a prematurely detected finish:
```
Jul  5 15:37:15.548: polling for jobs: 1 blocked, 2 running, 2 success
Jul  5 15:37:20.548: polling for jobs: 1 blocked, 1 running, 3 success
Build appears finished; checking 2 more times to make sure.
Jul  5 15:37:26.696: polling for jobs: 1 not_running, 1 running, 3 success
Build appears finished; checking 1 more times to make sure.
Jul  5 15:37:30.548: polling for jobs: 1 queued, 1 running, 3 success
Jul  5 15:37:35.548: polling for jobs: 2 running, 3 success
Jul  5 15:37:40.548: polling for jobs: 2 running, 3 success
```

It also will retry if the query to the CircleCI API to get the list of jobs fails, assuming it to be a transient failure (since by the time it gets to the retry code it has already successfully queried the CircleCI API for the workflow itself). If an API failure happens 3 times in a row it will also fail the job.

Finally this change adds some additional output to the watch command, changing it from just listing the time that it polls to also including a list of the number of jobs it found in each state.

Before:
```
polling for finished jobs:  Jul  3 23:59:04.068
polling for finished jobs:  Jul  3 23:59:09.120
polling for finished jobs:  Jul  3 23:59:14.186
polling for finished jobs:  Jul  3 23:59:19.237
```

After:
```
Jul  4 19:14:09.891: polling for jobs: 1 blocked, 2 running, 2 success
Jul  4 19:14:14.891: polling for jobs: 1 blocked, 2 running, 2 success
Jul  4 19:14:19.891: polling for jobs: 2 running, 3 success
Jul  4 19:14:24.891: polling for jobs: 2 running, 3 success
Jul  4 19:14:29.891: polling for jobs: 1 running, 4 success
Build appears finished; checking 2 more times to make sure.
Jul  4 19:14:34.891: polling for jobs: 1 running, 4 success
Build appears finished; checking 1 more times to make sure.
```