### PR TITLE
provide example of add_context in the buildevents build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,14 @@ jobs:
                 os: darwin
                 arch: amd64
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents-* artifacts/
+
+            ## just to serve as an example, let's add the size of the artifacts built to our trace
+            - run: echo "size=$(du -sb artifacts | cut -f 1)" >> $BASH_ENV
+            - buildevents/add_context:
+                field_name: artifacts_size_bytes
+                field_value: $size
+
+            ## ok, carry on and upload the artifacts
             - run: tar -cvf artifacts/buildevents.tar artifacts/buildevents-*
             - persist_to_workspace:
                 root: artifacts


### PR DESCRIPTION
As a convenient place to keep an example of how `add_context` should be used, let's add a record of the size of the artifacts produced by the `build` step in buildevent's build.

Depends on #28 - after that lands I'll rebase this and then the build should run.