### PR TITLE
switch to using RunE instead of Run for our commands

### DIFF
--- a/cmd_build.go
+++ b/cmd_build.go
@@ -22,7 +22,7 @@ when the build finishes and records the duration of the entire build. It emits
 a URL pointing to the generated trace in Honeycomb to STDOUT.`,
 		Args:                  argOptions(2, "success", "failure"),
 		DisableFlagsInUseLine: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			traceID := strings.TrimSpace(args[0])
 			startTime := parseUnix(strings.TrimSpace(args[1]))
 			outcome := strings.TrimSpace(args[2])
@@ -48,6 +48,8 @@ a URL pointing to the generated trace in Honeycomb to STDOUT.`,
 			} else {
 				fmt.Println(url)
 			}
+
+			return nil
 		},
 	}
 	return buildCmd

--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -35,7 +35,7 @@ will be launched via "bash -c" using "exec".`,
 			},
 		),
 		DisableFlagsInUseLine: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			traceID := strings.TrimSpace(args[0])
 			stepID := strings.TrimSpace(args[1])
 			name := strings.TrimSpace(args[2])
@@ -77,6 +77,8 @@ will be launched via "bash -c" using "exec".`,
 					"failure_reason": err.Error(),
 				})
 			}
+
+			return err
 		},
 	}
 	return execCmd

--- a/cmd_step.go
+++ b/cmd_step.go
@@ -20,7 +20,7 @@ one of "install", "before_script", "script", and so on. In CircleCI, this
 most closely maps to a single job. It should be run at the end of the step.`,
 		Args:                  cobra.ExactArgs(4),
 		DisableFlagsInUseLine: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			traceID := strings.TrimSpace(args[0])
 			stepID := strings.TrimSpace(args[1])
 			startTime := parseUnix(strings.TrimSpace(args[2]))
@@ -40,6 +40,8 @@ most closely maps to a single job. It should be run at the end of the step.`,
 				"duration_ms":     time.Since(startTime) / time.Millisecond,
 			})
 			ev.Timestamp = startTime
+
+			return nil
 		},
 	}
 	return stepCmd

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -45,7 +45,7 @@ build with the appropriate timers.`,
 				return nil
 			},
 		),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			traceID := strings.TrimSpace(args[0])
 
 			ev := createEvent(cfg, *ciProvider, traceID)
@@ -57,7 +57,7 @@ build with the appropriate timers.`,
 			ok, startTime, err := waitCircle(context.Background(), *wcfg)
 			if err != nil {
 				fmt.Printf("buildevents - Error detected: %s\n", err.Error())
-				os.Exit(1)
+				return err
 			}
 
 			status := "failed"
@@ -77,9 +77,11 @@ build with the appropriate timers.`,
 			url, err := buildURL(cfg, traceID, startTime.Unix())
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to create trace URL: %v\n", err)
-				return
+				return err
 			}
 			fmt.Println(url)
+
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Fixes #31 

In the `cmd` case, we need to handle the error returned from the subcommand, or we'll swallow it and return 0.  `watch` manually called `os.Exit(1)`, but cobra supports a `RunE` method on commands that has an `error` return.

Switch to `RunE`, return the proper error in `cmd_cmd.go`, and return the error instead of calling `os.Exit` in `cmd_watch.go`