### PR TITLE
bump orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.2.0
+  buildevents: honeycombio/buildevents@0.2.1
 
 executors:
   linuxgo:


### PR DESCRIPTION
v0.2.0 of the orb has a bug that's fixed in 0.2.1. Bumping to stay current.