### PR TITLE
disable cgo for alpine-linux compatability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,11 @@ commands:
     steps:
       ## method 1 to send a command span
       ## the raw buildevents binary is available in the $PATH but requires more arguments
+      ## don't use CGO so that this binary can run in alpine-linux containers
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
+          CGO_ENABLED=0 \
           buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID go_build -- \
           go build -ldflags "-X main.Version=${CIRCLE_TAG}" \
           -o $GOPATH/bin/buildevents-<< parameters.os >>-<< parameters.arch >> \


### PR DESCRIPTION
Using buildevents in the `cibuilds/base` docker image gave a confusing "file not found" error. Turns out alpine linux uses musl instead of libc, but disabling CGO is supposed to fix everything.