### PR TITLE
bump the orb version to 0.2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.2.1
+  buildevents: honeycombio/buildevents@0.2.3
 
 executors:
   linuxgo:


### PR DESCRIPTION
This is a bit chicken-vs-egg, but the buildevents version that works for finishing the trace after publishing is the one we just tagged (0.4.4).  Previous releases were still uploading the files to github, but the build was being flagged as failing on the publish step because of the cgo problem.

The orb that pulls in v0.4.4 of buildevents is v0.2.3, so bump our dep to that.
