### PR TITLE
Fix json annotation for workflow jobs listing

### DIFF
--- a/vendor/github.com/jszwedko/go-circleci/circleci.go
+++ b/vendor/github.com/jszwedko/go-circleci/circleci.go
@@ -374,7 +374,7 @@ func (c *Client) GetWorkflowV2(id string) (*WorkflowV2, error) {
 func (c *Client) ListWorkflowV2Jobs(id string, paginationToken *string) ([]*WorkflowJob, *string, error) {
 	type pagedJobs struct {
 		NextPageToken *string        `json:"next_page_token"`
-		Jobs          []*WorkflowJob `json:"jobs"`
+		Jobs          []*WorkflowJob `json:"items"`
 	}
 
 	// TODO if paginationToken is not nil, fetch the next page


### PR DESCRIPTION
`buildevents watch $CIRCLE_WORKFLOW_ID` mistakenly thinks a workflow is finished because it looks for the jobs contained in a workflow in the wrong attribute name in the JSON response from CircleCI.

You probably want to fix this upstream in `github.com/maplebed/go-circleci`, but that codebase seems to have shifted so I wasn't sure where to raise this.