### PR TITLE
use updated dependency on corrected  circleci api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 )
 
-replace github.com/jszwedko/go-circleci => github.com/maplebed/go-circleci v0.0.0-20190624145132-b886dbac393
+replace github.com/jszwedko/go-circleci => github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/maplebed/go-circleci v0.0.0-20190624145132-b886dbac393 h1:fGOOz/B38EXjZgOLiGAZxg48sqGInDMuysDi3aKSThQ=
-github.com/maplebed/go-circleci v0.0.0-20190624145132-b886dbac393/go.mod h1:OW/yiyLmpZqdbYUHRuFS83n1TpphzLe6sDFvOa8xX4w=
+github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d h1:VtCxoLvLWrlz/k3cWZhTQ90/BM4ex2/1dp8ClG4lmfM=
+github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d/go.mod h1:OW/yiyLmpZqdbYUHRuFS83n1TpphzLe6sDFvOa8xX4w=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/vendor/github.com/jszwedko/go-circleci/circleci.go
+++ b/vendor/github.com/jszwedko/go-circleci/circleci.go
@@ -374,7 +374,7 @@ func (c *Client) GetWorkflowV2(id string) (*WorkflowV2, error) {
 func (c *Client) ListWorkflowV2Jobs(id string, paginationToken *string) ([]*WorkflowJob, *string, error) {
 	type pagedJobs struct {
 		NextPageToken *string        `json:"next_page_token"`
-		Jobs          []*WorkflowJob `json:"jobs"`
+		Jobs          []*WorkflowJob `json:"items"`
 	}
 
 	// TODO if paginationToken is not nil, fetch the next page

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/honeycombio/libhoney-go
 github.com/honeycombio/libhoney-go/transmission
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jszwedko/go-circleci v0.2.0 => github.com/maplebed/go-circleci v0.0.0-20190624145132-b886dbac393
+# github.com/jszwedko/go-circleci v0.2.0 => github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d
 github.com/jszwedko/go-circleci
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 github.com/kr/logfmt


### PR DESCRIPTION
Taking the change suggested in #46 and using the new copy of go-circleci that contains it.