### PR TITLE
update go-circleci dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 )
 
-replace github.com/jszwedko/go-circleci => github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d
+replace github.com/jszwedko/go-circleci => github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d h1:VtCxoLvLWrlz/k3cWZhTQ90/BM4ex2/1dp8ClG4lmfM=
 github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d/go.mod h1:OW/yiyLmpZqdbYUHRuFS83n1TpphzLe6sDFvOa8xX4w=
+github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e h1:3bo8bGTgwaDE4CU+BNg/CVvHDUJJ0m6biuIBa78erzM=
+github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e/go.mod h1:OW/yiyLmpZqdbYUHRuFS83n1TpphzLe6sDFvOa8xX4w=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/vendor/github.com/jszwedko/go-circleci/circleci.go
+++ b/vendor/github.com/jszwedko/go-circleci/circleci.go
@@ -380,7 +380,7 @@ func (c *Client) ListWorkflowV2Jobs(id string, paginationToken *string) ([]*Work
 	// TODO if paginationToken is not nil, fetch the next page
 
 	jobListing := &pagedJobs{}
-	err := c.request("GET", fmt.Sprintf("workflow/%s/jobs", id), jobListing, nil, nil, apiV2)
+	err := c.request("GET", fmt.Sprintf("workflow/%s/job", id), jobListing, nil, nil, apiV2)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -920,9 +920,9 @@ type WorkflowJob struct {
 	Name         string     `json:"name"`         // : "js_build",
 	ProjectSlug  string     `json:"project_slug"` // : "github/myorg/test",
 	Status       string     `json:"status"`       // : "success",
-	StopTime     *time.Time `json:"stop_time"`    // : "2019-06-20T23:19:50Z",
+	StopTime     *time.Time `json:"stopped_at"`    // : "2019-06-20T23:19:50Z",
 	Type         string     `json:"type"`         // : "build",
-	StartTime    time.Time  `json:"start_time"`   // : "2019-06-20T23:18:04Z"
+	StartTime    time.Time  `json:"started_at"`   // : "2019-06-20T23:18:04Z"
 }
 
 // Build represents the details of a build

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/honeycombio/libhoney-go
 github.com/honeycombio/libhoney-go/transmission
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jszwedko/go-circleci v0.2.0 => github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d
+# github.com/jszwedko/go-circleci v0.2.0 => github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e
 github.com/jszwedko/go-circleci
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 github.com/kr/logfmt


### PR DESCRIPTION
Update `github.com/maplebed/go-circleci` to fix a couple of v2 api breakages (the most recent one causes the `watch` command to 404 for all its requests).