### PR TITLE
Call libhoney.Close when commands return an error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 
 	// Do the work
 	if err := root.Execute(); err != nil {
+		libhoney.Close()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
defers don't get run when os.Exit is called, so we need to explicitly call libhoney.Close to
make sure that events from `buildevents cmd` with a non-zero exit status get sent.