### PR TITLE
Correct psuedo-version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 )
 
-replace github.com/jszwedko/go-circleci => github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e
+replace github.com/jszwedko/go-circleci => github.com/maplebed/go-circleci v0.2.1-0.20191121000249-089ef54587e5

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d h1:VtCxoLvLWrlz/k3cWZhTQ90/BM4ex2/1dp8ClG4lmfM=
-github.com/maplebed/go-circleci v0.0.0-20191002151007-b2b19c1493d/go.mod h1:OW/yiyLmpZqdbYUHRuFS83n1TpphzLe6sDFvOa8xX4w=
-github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e h1:3bo8bGTgwaDE4CU+BNg/CVvHDUJJ0m6biuIBa78erzM=
-github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e/go.mod h1:OW/yiyLmpZqdbYUHRuFS83n1TpphzLe6sDFvOa8xX4w=
+github.com/maplebed/go-circleci v0.2.1-0.20191121000249-089ef54587e5 h1:O4HwrOLgNCy5jYsUfXv/sjjOCWjdNNTzUIf3d9vkUhc=
+github.com/maplebed/go-circleci v0.2.1-0.20191121000249-089ef54587e5/go.mod h1:OW/yiyLmpZqdbYUHRuFS83n1TpphzLe6sDFvOa8xX4w=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,21 +1,38 @@
 # github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
+## explicit
 github.com/facebookgo/clock
+# github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51
+## explicit
 # github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01
+## explicit
 github.com/facebookgo/limitgroup
 # github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52
+## explicit
 github.com/facebookgo/muster
+# github.com/facebookgo/stack v0.0.0-20160209184415-751773369052
+## explicit
+# github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870
+## explicit
 # github.com/honeycombio/libhoney-go v1.10.0
+## explicit
 github.com/honeycombio/libhoney-go
 github.com/honeycombio/libhoney-go/transmission
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jszwedko/go-circleci v0.2.0 => github.com/maplebed/go-circleci v0.0.0-20191121030249-089ef54587e
+# github.com/jszwedko/go-circleci v0.2.0 => github.com/maplebed/go-circleci v0.2.1-0.20191121000249-089ef54587e5
+## explicit
 github.com/jszwedko/go-circleci
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+## explicit
 github.com/kr/logfmt
 # github.com/spf13/cobra v0.0.5
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.3
 github.com/spf13/pflag
+# github.com/stretchr/testify v1.3.0
+## explicit
 # gopkg.in/alexcesaro/statsd.v2 v2.0.0
+## explicit
 gopkg.in/alexcesaro/statsd.v2
+# github.com/jszwedko/go-circleci => github.com/maplebed/go-circleci v0.2.1-0.20191121000249-089ef54587e5


### PR DESCRIPTION
It looks like new tags were added to the repo, causing the psuedo version to change

I also re-ran go mod vendor, which made more changes to modules.txt than I expected