### PR TITLE
Simplify subprocess IO management.

### DIFF
--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/rand"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -91,26 +90,8 @@ func runCommand(subcmd string) error {
 	fmt.Println("running /bin/bash -c", subcmd)
 	cmd := exec.Command("/bin/bash", "-c", subcmd)
 
-	outReader, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	errReader, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-	err = cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	go func() {
-		io.Copy(os.Stdout, outReader)
-	}()
-	go func() {
-		io.Copy(os.Stderr, errReader)
-	}()
-
-	return cmd.Wait()
+	return cmd.Run()
 }


### PR DESCRIPTION
The previous version used two goroutines calling `io.Copy`.

Unfortunately it did not check the return value of `io.Copy` and in
production we saw some hangs which looked like they might be caused if
one or both `io.Copy`s failed but `cmd.Wait` didn't return.

This version is much simpler and just hooks up the parent's Stdout/Stderr
to the child's Stdout/Stderr directly.