### PR TITLE
Silence usage on cmd error.  Fixes #45

### DIFF
--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -36,6 +36,11 @@ will be launched via "bash -c" using "exec".`,
 		),
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Don't show usage if RunE returns an error. This set in RunE
+			// instead of when we instantiate the cmd so we don't suppress usage
+			// for errors from Args.
+			cmd.SilenceUsage = true
+
 			traceID := strings.TrimSpace(args[0])
 			stepID := strings.TrimSpace(args[1])
 			name := strings.TrimSpace(args[2])


### PR DESCRIPTION
Show usage for errors returned by Args:

```
❯ go run github.com/honeycombio/buildevents cmd build step name false
Error: use `--` to signify shell command
Usage:
  buildevents cmd [flags] BUILD_ID STEP_ID NAME -- [shell command to execute]

Flags:
  -h, --help   help for cmd

Global Flags:
  -a, --apihost string    [env.BUILDEVENT_APIHOST] the hostname for the Honeycomb API server to which to send this event (default "https://api.honeycomb.io")
  -k, --apikey string     [env.BUILDEVENT_APIKEY] the Honeycomb authentication token
  -d, --dataset string    [env.BUILDEVENT_DATASET] the name of the Honeycomb dataset to which to send these events (default "buildevents")
  -f, --filename string   [env.BUILDEVENT_FILE] the path of a text file holding arbitrary key=val pairs (multi-line-capable, logfmt style) to be added to the Honeycomb event
  -p, --provider string   [env.BUILDEVENT_CIPROVIDER] if unset, will inspect the environment to try and detect Travis-CI, CircleCI, or GitLab-CI.

exit status 1
```

Suppress usage for errors returned by RunE:

```
❯ go run github.com/honeycombio/buildevents cmd build step name -- false 
running /bin/bash -c "false"
{"data":{"cmd":"\"false\"","duration_ms":3,"failure_reason":"exit status 1","meta.version":"dev","name":"name","service_name":"cmd","status":"failure","trace.parent_id":"step","trace.span_id":"746e2e623310604928dcddf2a913df49","trace.trace_id":"build"},"time":"2020-02-20T21:01:14.600388-08:00","dataset":"buildevents"}
Error: exit status 1
exit status 1
```