### PR TITLE
Add support for Azure Pipelines

### DIFF
--- a/cmd_root.go
+++ b/cmd_root.go
@@ -52,6 +52,8 @@ about your Continuous Integration builds.`,
 			prov = providerJenkinsX
 		} else if _, present := os.LookupEnv("GOOGLE-CLOUD-BUILD"); present {
 			prov = providerGoogleCloudBuild
+		} else if _, present := os.LookupEnv("TF_BUILD"); present {
+			prov = providerAzurePipelines
 		}
 	}
 	if prov != "" {

--- a/common.go
+++ b/common.go
@@ -92,6 +92,19 @@ func providerInfo(provider string, ev *libhoney.Event) {
 			"REPO_OWNER":  "pr_user",
 			"REPO_NAME":   "repo",
 		}
+	case "azure-pipelines", "azure-devops", "vsts", "tfs":
+		envVars = map[string]string{
+			"BUILD_SOURCEBRANCHNAME":               "branch",
+			"BUILD_BUILDID":                        "build_id",
+			"BUILD_BUILDNUMBER":                    "build_number",
+			"SYSTEM_JOBDISPLAYNAME":                "job_name",
+			"SYSTEM_STAGEDISPLAYNAME":              "stage_name",
+			"SYSTEM_PULLREQUEST_PULLREQUESTID":     "pr_id",
+			"SYSTEM_PULLREQUEST_PULLREQUESTNUMBER": "pr_number",
+			"SYSTEM_PULLREQUEST_SOURCEBRANCH":      "pr_branch",
+			"BUILD_REQUESTEDFOR":                   "build_user",
+			"BUILD_REPOSITORY_URI":                 "repo",
+		}
 	}
 	for envVar, fieldName := range envVars {
 		if val, ok := os.LookupEnv(envVar); ok {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ const (
 	providerGitLab           = "GitLab-CI"
 	providerJenkinsX         = "Jenkins-X"
 	providerGoogleCloudBuild = "Google-Cloud-Build"
+	providerAzurePipelines   = "Azure-Piplines"
 )
 
 func main() {


### PR DESCRIPTION
I kept with the naming that the other providers used where possible. For PRs there is both ID and Number, the first for PRs created using Azure Repos and the second for PRs created in Github.