### PR TITLE
Correct a download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ env:
 install:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo install | sum | cut -f 1 -d \ )
-  - curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+  - curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-linux-amd64
   - chmod 755 buildevents
   - # ... any other setup necessary for your build
   - ./buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START install


### PR DESCRIPTION
With the old value this fetches a text document that contains "Not found"
and raises "Not: command not found in TravisCI." I think being explicit
with the architecture here is fine as by default it is what TravisCI
will use.