### PR TITLE
add GitHub actions as a supported CI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The Build ID may already be available in the environment for your build:
 * GitLab-CI: `CI_PIPELINE_ID`
 * JenkinsX: `JENKINSX_BUILD_NUMBER`
 * Google-Cloud-Build: `BUILD_ID`
+* GitHub Actions: `GITHUB_RUN_ID`
+
 # Use
 
 Now that `buildevents` is installed and configured, actually generating spans to send to Honeycomb involves invoking `buildevents` in various places throughout your build config.

--- a/cmd_root.go
+++ b/cmd_root.go
@@ -39,7 +39,7 @@ about your Continuous Integration builds.`,
 		root.PersistentFlags().Lookup("filename").Value.Set(fname)
 	}
 
-	root.PersistentFlags().StringVarP(ciProvider, "provider", "p", "", "[env.BUILDEVENT_CIPROVIDER] if unset, will inspect the environment to try and detect Travis-CI, CircleCI, or GitLab-CI.")
+	root.PersistentFlags().StringVarP(ciProvider, "provider", "p", "", "[env.BUILDEVENT_CIPROVIDER] if unset, will inspect the environment to try to detect common CI providers.")
 	prov := os.Getenv("BUILDEVENT_CIPROVIDER")
 	if prov == "" {
 		if _, present := os.LookupEnv("TRAVIS"); present {
@@ -52,6 +52,8 @@ about your Continuous Integration builds.`,
 			prov = providerJenkinsX
 		} else if _, present := os.LookupEnv("GOOGLE-CLOUD-BUILD"); present {
 			prov = providerGoogleCloudBuild
+		} else if _, present := os.LookupEnv("GITHUB_ACTIONS"); present {
+			prov = providerGitHubActions
 		}
 	}
 	if prov != "" {

--- a/common.go
+++ b/common.go
@@ -92,6 +92,16 @@ func providerInfo(provider string, ev *libhoney.Event) {
 			"REPO_OWNER":  "pr_user",
 			"REPO_NAME":   "repo",
 		}
+
+	case "github-actions", "githubactions", "github":
+		envVars = map[string]string{
+			"GITHUB_REF":        "branch",
+			"GITHUB_RUN_ID":     "build_num",
+			"GITHUB_WORKFLOW":   "workflow_name",
+			"GITHUB_HEAD_REF":   "pr_branch",
+			"GITHUB_ACTOR":      "pr_user",
+			"GITHUB_REPOSITORY": "repo",
+		}
 	}
 	for envVar, fieldName := range envVars {
 		if val, ok := os.LookupEnv(envVar); ok {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ const (
 	providerGitLab           = "GitLab-CI"
 	providerJenkinsX         = "Jenkins-X"
 	providerGoogleCloudBuild = "Google-Cloud-Build"
+	providerGitHubActions    = "GitHub-Actions"
 )
 
 func main() {


### PR DESCRIPTION
This adds support/automatic detection of GitHub Actions as a CI provider.

They have a doc here listing the env vars provided by the runner, from which I pulled what looked like the most relevant ones: https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables