### PR TITLE
Encode spaces in dataset names for the URL

### DIFF
--- a/common.go
+++ b/common.go
@@ -177,7 +177,7 @@ func buildURL(cfg *libhoney.Config, traceID string, ts int64) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to infer UI host: %s", uiHost)
 	}
-	u.Path = path.Join(teamName, "datasets", cfg.Dataset, "trace")
+	u.Path = path.Join(teamName, "datasets", strings.Replace(cfg.Dataset, " ", "-", -1), "trace")
 	endTime := time.Now().Add(10 * time.Minute).Unix()
 	return fmt.Sprintf(
 		"%s?trace_id=%s&trace_start_ts=%d&trace_end_ts=%d",


### PR DESCRIPTION
The ui.honeycomb.com URLs for datasets with spaces in the name use a `-` (dash) for encoding that space. This change fixes the `buildURL` function to also use dashes for spaces, instead of exposing the space character.

This fixes #72 