### PR TITLE
Add support for overriding default fields

### DIFF
--- a/cmd_build.go
+++ b/cmd_build.go
@@ -31,7 +31,6 @@ a URL pointing to the generated trace in Honeycomb to STDOUT.`,
 			defer ev.Send()
 
 			providerInfo(*ciProvider, ev)
-			arbitraryFields(*filename, ev)
 
 			ev.Add(map[string]interface{}{
 				"service_name":  "build",
@@ -41,6 +40,8 @@ a URL pointing to the generated trace in Honeycomb to STDOUT.`,
 				"duration_ms":   time.Since(startTime) / time.Millisecond,
 			})
 			ev.Timestamp = startTime
+
+			arbitraryFields(*filename, ev)
 
 			url, err := buildURL(cfg, traceID, startTime.Unix())
 			if err != nil {

--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -62,10 +62,6 @@ will be launched via "bash -c" using "exec".`,
 			err := runCommand(subcmd)
 			dur := time.Since(start)
 
-			// Annotate with arbitrary fields after the command runs
-			// this way we can consume a file if the command itself generated one
-			arbitraryFields(*filename, ev)
-
 			ev.Add(map[string]interface{}{
 				"trace.parent_id": stepID,
 				"trace.span_id":   fmt.Sprintf("%x", spanBytes),
@@ -75,6 +71,10 @@ will be launched via "bash -c" using "exec".`,
 				"cmd":             subcmd,
 			})
 			ev.Timestamp = start
+
+			// Annotate with arbitrary fields after the command runs
+			// this way we can consume a file if the command itself generated one
+			arbitraryFields(*filename, ev)
 
 			if err == nil {
 				ev.AddField("status", "success")

--- a/cmd_step.go
+++ b/cmd_step.go
@@ -30,7 +30,6 @@ most closely maps to a single job. It should be run at the end of the step.`,
 			defer ev.Send()
 
 			providerInfo(*ciProvider, ev)
-			arbitraryFields(*filename, ev)
 
 			ev.Add(map[string]interface{}{
 				"trace.parent_id": traceID,
@@ -40,6 +39,8 @@ most closely maps to a single job. It should be run at the end of the step.`,
 				"duration_ms":     time.Since(startTime) / time.Millisecond,
 			})
 			ev.Timestamp = startTime
+
+			arbitraryFields(*filename, ev)
 
 			return nil
 		},

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -56,7 +56,6 @@ build with the appropriate timers.`,
 			defer ev.Send()
 
 			providerInfo(*ciProvider, ev)
-			arbitraryFields(*filename, ev) // TODO: consider - move this until after the watch timeout??
 
 			ok, startTime, endTime, err := waitCircle(context.Background(), *wcfg)
 			if err != nil {
@@ -77,6 +76,8 @@ build with the appropriate timers.`,
 				"duration_ms":   endTime.Sub(startTime) / time.Millisecond,
 			})
 			ev.Timestamp = startTime
+
+			arbitraryFields(*filename, ev) // TODO: consider - move this until after the watch timeout??
 
 			url, err := buildURL(cfg, traceID, startTime.Unix())
 			if err != nil {


### PR DESCRIPTION
This is an option for addressing https://github.com/honeycombio/buildevents/issues/75

Loading the `$BUILDEVENT_FILE` after default fields are added to the event
allows them to be overridden. This will make it possible to add spans nested
under children of the root span (by overriding `trace.parent_id`), and will
also add support for customizing other default fields like `service_name`.
