### PR TITLE
Use public CircleCI context for build secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,28 +134,33 @@ workflows:
   build:
     jobs:
       - setup:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - test:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - build:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - test
           filters:
             tags:
               only: /.*/
       - smoketest:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ workflows:
             tags:
               only: /.*/
       - publish:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - smoketest
           filters:


### PR DESCRIPTION
* currently secrets are pulled from the project env variables in CircleCI
* using a shared context consolidates secrets storage, makes for easier secret updates
* majority of other repos already use the shared context, looks like this was set up
a while back before the context was created
* secret values are unchanged from what's currently in the project env variables