### PR TITLE
Ensure PRs from forks can run CI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,13 @@ jobs:
 workflows:
   build_forked:
     jobs:
+      - setup:
+          filters:
+            branches:
+              only: /pull\/.*/
       - test:
+          requires:
+            - setup
           filters:
             branches:
               only: /pull\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,25 @@ jobs:
                   ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-darwin-amd64
 
 workflows:
+  build_forked:
+    jobs:
+      - test:
+          filters:
+            branches:
+              only: /pull\/.*/
+      - build:
+          requires:
+            - test
+          filters:
+            branches:
+              only: /pull\/.*/
+      - smoketest:
+          requires:
+            - build
+          filters:
+            branches:
+              only: /pull\/.*/
+
   build:
     jobs:
       - setup:
@@ -138,6 +157,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
       - watch:
           context: Honeycomb Secrets for Public Repos
           requires:
@@ -145,6 +166,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
       - test:
           context: Honeycomb Secrets for Public Repos
           requires:
@@ -152,6 +175,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
       - build:
           context: Honeycomb Secrets for Public Repos
           requires:
@@ -159,6 +184,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
       - smoketest:
           context: Honeycomb Secrets for Public Repos
           requires:
@@ -166,6 +193,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
       - publish:
           context: Honeycomb Secrets for Public Repos
           requires:


### PR DESCRIPTION
PRs from forks were [unauthorized](https://app.circleci.com/pipelines/github/honeycombio/buildevents?branch=pull%2F80) to run CI builds due to a restricted secrets context. Changes in this PR are following the same pattern as [otel-exporter-python](https://github.com/honeycombio/opentelemetry-exporter-python/pull/21)

### Changes
* add build_forked workflow without buildevents, so forked PRs can run builds
* exclude forked PRs from the main workflow