### PR TITLE
Another GitLab CI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,81 @@ workflows:
             - test
 ```
 
+GitLab CI example:
+```yaml
+# Not a huge fan of YAML anchors, but it's the easiest way to
+# extend the scripts in jobs where you need other before_script and after_script
+.default_before_script: &default_before_script
+  - STEP_START=$(date +%s)
+  - STEP_SPAN_ID=$(echo $CI_JOB_NAME | sum | cut -f 1 -d \ )
+  - echo "export STEP_START=$STEP_START" >> buildevents/env
+  - echo "export STEP_SPAN_ID=$STEP_SPAN_ID" >> buildevents/env
+  - echo "export PATH=\"$PATH:buildevents/bin/\"" >> buildevents/env
+  - source buildevents/env
+  - cat buildevents/env
+
+.default_after_script: &default_after_script
+  - source buildevents/env
+  - cat buildevents/env
+  - buildevents step $CI_PIPELINE_ID $STEP_SPAN_ID $STEP_START $CI_JOB_NAME
+
+default:
+  image: golang:latest
+  before_script:
+    - *default_before_script
+  after_script:
+    - *default_after_script
+
+stages:
+  # .pre and .post are guaranteed to be first and last run jobs
+  # https://docs.gitlab.com/ee/ci/yaml/README.html#pre-and-post
+  - .pre
+  - build
+  - test
+  - .post
+
+setup:
+  before_script:
+    - mkdir -p buildevents/bin/
+    - *default_before_script
+  script:
+    - curl -L -o main https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-linux-amd64
+    - chmod 755 main
+    - mv main buildevents/bin/buildevents
+    - export BUILD_START=$(date +%s)
+    - echo "export BUILD_START=$(date +%s)" >> buildevents/env
+  artifacts:
+    paths:
+      - buildevents
+  stage: .pre
+
+go_build:
+  script:
+    - buildevents cmd $CI_PIPELINE_ID $STEP_SPAN_ID build -- go install ./...
+  stage: build
+
+go_test:
+  script:
+    - buildevents cmd $CI_PIPELINE_ID $STEP_SPAN_ID build -- go test ./...
+  stage: test
+
+send_success_trace:
+  script:
+    - "traceURL=$(buildevents build $CI_PIPELINE_ID $BUILD_START success)"
+    - "echo \"Honeycomb Trace: $traceURL\""
+  stage: .post
+  rules:
+    - when: on_success
+
+send_failure_trace:
+  script:
+    - "traceURL=$(buildevents build $CI_PIPELINE_ID $BUILD_START failure)"
+    - "echo \"Honeycomb Trace: $traceURL\""
+  stage: .post
+  rules:
+    - when: on_failure
+```
+
 # Positional argument reference
 
 All the arguments to the various `buildevents` modes are listed above, but for


### PR DESCRIPTION
This is pretty gross and not very ergonomic, but I'm not sure if there are better ways.

It looks like other CI providers have much better ways to do some of this instrumentation.

Tests on https://gitlab.com/zoidyzoidzoid/buildevents-mirror/-/pipelines

![image](https://user-images.githubusercontent.com/2572493/111969638-c1094780-8afa-11eb-8d1d-b7b3e0ad9bf4.png)

I'm gonna copy this and test it on a large internal repo today.

