### PR TITLE
Build an arm64 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
       arch:
         description: Target architecture
         type: enum
-        enum: ["386", "amd64"]
+        enum: ["386", "amd64", "arm64"]
         default: "amd64"
     steps:
       ## method 1 to send a command span
@@ -71,6 +71,9 @@ jobs:
             - go-build:
                 os: darwin
                 arch: amd64
+            - go-build:
+                os: linux
+                arch: arm64
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents-* artifacts/
 
             ## just to serve as an example, let's add the size of the artifacts built to our trace
@@ -126,9 +129,10 @@ jobs:
                   echo "about to publish to tag ${CIRCLE_TAG}"
                   tar -xvf artifacts/buildevents.tar
                   ls -l *
-                  ghr --draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-linux-386
-                  ghr --draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-linux-amd64
-                  ghr --draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-darwin-amd64
+                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-linux-386
+                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-linux-amd64
+                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-linux-arm64
+                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/buildevents-darwin-amd64
 
 workflows:
   build:

--- a/README.md
+++ b/README.md
@@ -23,12 +23,26 @@ If you have a working go environment in your build, the easiest way to install `
 go get github.com/honeycombio/buildevents/
 ```
 
-There are also built binaries for linux and macOS hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab. The following two commands will down load and make executable the github-hosted binary.
+There are also built binaries for linux and macOS hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab. The following commands will download and make executable the github-hosted binary.
 
-**linux:**
+**linux, 32-bit x86:**
+
+```
+curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-linux-386
+chmod 755 buildevents
+```
+
+**linux, 64-bit x86:**
 
 ```
 curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-linux-amd64
+chmod 755 buildevents
+```
+
+**linux, arm64:**
+
+```
+curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-linux-arm64
 chmod 755 buildevents
 ```
 


### PR DESCRIPTION
(This is a precursor to adding the arm release to
https://github.com/honeycombio/buildevents-orb)