### PR TITLE
stop watching dependabot builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,9 @@ workflows:
             tags:
               only: /.*/
             branches:
-              ignore: /pull\/.*/
+              ignore:
+              - /pull\/.*/
+              - /dependabot\/.*/
       - test:
           requires:
             - setup


### PR DESCRIPTION
dependabot does not have access to secrets necessary to watch builds

in action: https://app.circleci.com/pipelines/github/honeycombio/buildevents/266/workflows/a030bb30-ea38-40eb-9074-915099387362