### PR TITLE
Allow specifying an alternative shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Now that `buildevents` is installed and configured, actually generating spans to
 `buildevents` is invoked with one of three modes, `build`, `step`, and `cmd`.
 * The `build` mode sends the root span for the entire build. It should be called when the build finishes and records the duration of the entire build. It emits a URL pointing to the generated trace in Honeycomb to STDOUT.
 * The `step` mode represents a block of related commands. In Travis-CI, this is one of `install`, `before_script`, `script`, and so on. In CircleCI, this most closely maps to a single job. It should be run at the end of the step.
-* The `cmd` mode invokes an individual command that is part of the build, such as running DB migrations or running a specific test suite. It must be able to be expressed as a single shell command - either a process like `go test` or a shell script. The command to run is the final argument to `buildevents` and will be launched via `bash -c` using `exec`.
+* The `cmd` mode invokes an individual command that is part of the build, such as running DB migrations or running a specific test suite. It must be able to be expressed as a single shell command - either a process like `go test` or a shell script. The command to run is the final argument to `buildevents` and will be launched via `bash -c` using `exec`. You can specify an alternate shell using the `-s/--shell` flag but it must support the the `-c` flag.
 
 ## build
 

--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -107,7 +107,7 @@ will be launched via "bash -c" using "exec". The shell can be changed with the
 	var quiet bool
 	var shell string
 	execCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "silence non-cmd output")
-	execCmd.Flags().StringVarP(&shell, "shell", "s", "/bin/bash", "use and alternative shell")
+	execCmd.Flags().StringVarP(&shell, "shell", "s", "/bin/bash", "path of shell executable to use for command, must accept -c as an argument")
 	return execCmd
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

I think this could be considered a solution to https://github.com/honeycombio/buildevents/issues/88 but maybe not since it doesn't try to do any sort of auto-detection of shells.

## Short description of the changes

Add a new flag on the `cmd` subcommand to run with an alternate shell. My personal use case is switching it to `/bin/sh` for alpine images.