### PR TITLE
Bump libhoney-go to v1.15.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/honeycombio/beeline-go v1.2.0
-	github.com/honeycombio/libhoney-go v1.15.5
+	github.com/honeycombio/libhoney-go v1.15.6
 	github.com/jszwedko/go-circleci v0.3.0
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 	github.com/spf13/cobra v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/honeycombio/beeline-go v1.2.0 h1:eRMi84j6SIyRJU8lbb0KlKFISGW8Lc5SxMNce1Dq3SE=
 github.com/honeycombio/beeline-go v1.2.0/go.mod h1:fja0Qzbvi6VaGiZS3N1/D4jmNXXNEGtrGqR5QC31DvE=
 github.com/honeycombio/libhoney-go v1.15.4/go.mod h1:heFH+SMgmpF2m3aHwnQqUS5feImLHnzP6RaIvFkWsKU=
-github.com/honeycombio/libhoney-go v1.15.5 h1:Djren7ovq6pnPljEow3F1uu3FCc9ailigm9qtTPpEWA=
-github.com/honeycombio/libhoney-go v1.15.5/go.mod h1:8NyBoM746bz+nw3yQzQF8gtJO/z4mkr/MD5C4r4uC2Y=
+github.com/honeycombio/libhoney-go v1.15.6 h1:zbwfdo74Gsedmu6OT/oAHv4pfKNoseTXRMA/4e5XWew=
+github.com/honeycombio/libhoney-go v1.15.6/go.mod h1:8NyBoM746bz+nw3yQzQF8gtJO/z4mkr/MD5C4r4uC2Y=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=


### PR DESCRIPTION
## Which problem is this PR solving?
Bumps libhoney-go to v1.15.6.

## Short description of the changes
- bump libhoney-go to v1.15.6 in go.mod/sum
