### PR TITLE
do not fail the build if buildURL does not verify API key

### DIFF
--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -82,10 +82,9 @@ build with the appropriate timers.`,
 			url, err := buildURL(cfg, traceID, startTime.Unix())
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to create trace URL: %v\n", err)
-				return err
+			} else {
+				fmt.Println(url)
 			}
-			fmt.Println(url)
-
 			return nil
 		},
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- `buildURL` in the watch command calls libhoney's `VerifyAPIKey` which calls out to the Honeycomb API. If there is an error in this step, the entire build will fail. This could happen both if your API Key is not valid or if the Honeycomb API is inaccessible. If this step fails we should log and continue, rather than returning an error and failing the entire build. Note that this is similar to how `buildURL` is currently handled by the build command: https://github.com/honeycombio/buildevents/blob/main/cmd_build.go#L46

## Short description of the changes
 
- If `buildURL` fails, log and continue rather than erroring.

