### PR TITLE
Display underlying error when verifying API key

### DIFF
--- a/common.go
+++ b/common.go
@@ -189,7 +189,7 @@ func parseUnix(ts string) time.Time {
 func buildURL(cfg *libhoney.Config, traceID string, ts int64) (string, error) {
 	teamName, err := libhoney.VerifyAPIKey(*cfg)
 	if err != nil {
-		return "", fmt.Errorf("unable to verify API key")
+		return "", fmt.Errorf("unable to verify API key: %w", err)
 	}
 	uiHost := strings.Replace(cfg.APIHost, "api", "ui", 1)
 	u, err := url.Parse(uiHost)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- The error message `Unable to create trace URL: unable to verify API key` could be clearer. This PR prints the underlying error. Here how I came up to this: 
  - I had misread the `BUILDEVENT_APIKEY` in the docs and actually used `BUILDEVENT_API_KEY`
  - I thus wrongly assumed there was some issue elsewhere because even re-reading the docs, the missing `_` is hard to see (that's on me!) 
  - I applied the patch in this PR to actually see what was the issue. 
  - It showed me a message about the key being blank, so it finally clicked and I saw the missing `_`.

At this point, I thought I'd rather submit a PR just in case you find it appropriate :) 

This (probably?) addresses https://github.com/honeycombio/buildevents/issues/92.

## Short description of the changes

- It just prints the underlying error from `libhoney` when it cannot verify the API key. 

