### PR TITLE
Return underlying exit code when running commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"errors"
 	"os"
+
+	"os/exec"
 
 	libhoney "github.com/honeycombio/libhoney-go"
 )
@@ -41,6 +44,13 @@ func main() {
 	// Do the work
 	if err := root.Execute(); err != nil {
 		libhoney.Close()
+
+		// If the underlying command returned a specific exit code, we need
+		// to exit it with it as well to act transparently.
+		var cmdErr *exec.ExitError
+		if errors.As(err, &cmdErr) {
+			os.Exit(cmdErr.ExitCode())
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- `buildevents cmd` shadows any specific exit code returned by commands it was asked to run.
- This prevents CI scripts that rely on specific exit codes to detect, for example, soft failures (that was what happened to us in this case). 

## Short description of the changes

- When `buildevents cmd` is called, if there is an error, it will check if that's a `exec.ExitError` and will return the associated exit code instead of plainly exting with a code `1`. 

I tested this on our own CI system with success. 

<details>
  <summary>Small snippet if you want to see for yourself</summary>

```
~/play/foobar $ ./foobar
27
Error: exit status 27
Usage:
  hugo [flags]

Flags:
  -h, --help   help for hugo

exit status 27
here 27
~/play/foobar $ echo $?
27
```

```go
package main

import (
	"errors"
	"fmt"
	"os"
	"os/exec"

	"github.com/spf13/cobra"
)

func main() {
	if err := rootCmd.Execute(); err != nil {
		fmt.Println(err)
		var cmdErr *exec.ExitError
        // The original code did not have these three lines. Comment it so see the 
        // original behaviour. Check with echo $?. 
		if errors.As(err, &cmdErr) {
			fmt.Println("here", cmdErr.ExitCode())
			os.Exit(cmdErr.ExitCode())
		}
		os.Exit(1)
	}
}

var rootCmd = &cobra.Command{
	Use:   "hugo",
	Short: "Hugo is a very fast static site generator",
	Long: `A Fast and Flexible Static Site Generator built with
                love by spf13 and friends in Go.
                Complete documentation is available at http://hugo.spf13.com`,
	RunE: func(cmd *cobra.Command, args []string) error {
		cc := exec.Command("/bin/bash", "-c", "exit 27")

		cc.Stdout = os.Stdout
		cc.Stderr = os.Stderr
		cc.Stdin = os.Stdin

		err := cc.Run()

		fmt.Printf("%#v\n", err.(*exec.ExitError).ExitCode())
		return err
	},
}
```

</details>  

