### PR TITLE
remove erroneous default value

### DIFF
--- a/cmd_root.go
+++ b/cmd_root.go
@@ -63,7 +63,7 @@ about your Continuous Integration builds.`,
 		root.PersistentFlags().Lookup("apikey").Value.Set(apikey)
 	}
 
-	root.PersistentFlags().StringVarP(&cfg.Dataset, "dataset", "d", "buildevents", "[env.BUILDEVENT_DATASET] the name of the Honeycomb dataset to which to send these events")
+	root.PersistentFlags().StringVarP(&cfg.Dataset, "dataset", "d", "", "[env.BUILDEVENT_DATASET] the name of the Honeycomb dataset to which to send these events")
 	if dataset, ok := os.LookupEnv("BUILDEVENT_DATASET"); ok {
 		root.PersistentFlags().Lookup("dataset").Value.Set(dataset)
 	}


### PR DESCRIPTION
In reworking the commits for the new version, I mistakenly restored a default value for the dataset that shouldn't be there. This removes it. Defaults are now applied in code based on logic.

Requires release of 0.9.1.