### PR TITLE
[docs] update orb when releasing

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,6 @@
 # Creating a new release
 
-1. Add new entry in the CHANGELOG.
-
-2. Once the above change is merged into `main`, tag `main` with the new version, e.g. `v0.6.1`. Push the tags. This will kick off CI, which will create a draft GitHub release.
-
-3. Update release notes using the CHANGELOG entry on the new draft GitHub release, and publish it.
+1. Prep update PR for the [orb](https://github.com/honeycombio/buildevents-orb) with the new version of buildevents.
+2. Add new entry in the CHANGELOG.
+3. Once the above change is merged into `main`, tag `main` with the new version, e.g. `v0.6.1`. Push the tags. This will kick off CI, which will create a draft GitHub release.
+4. Update release notes using the CHANGELOG entry on the new draft GitHub release, and publish it.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- we often forget to update the orb when releasing buildevents

## Short description of the changes

- add to releasing step as first step based on team conversation about doing one-off releasing tasks early

