### PR TITLE
Build Darwin arm64 too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,9 @@ jobs:
                 os: darwin
                 arch: amd64
             - go-build:
+                os: darwin
+                arch: arm64
+            - go-build:
                 os: linux
                 arch: arm64
             - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents-* artifacts/


### PR DESCRIPTION
## Which problem is this PR solving?

- Adds Darwin arm64 binary to the artifacts list
- Fixes #156 


