### PR TITLE
add gha-buildevents as GHA provider alias

### DIFF
--- a/common.go
+++ b/common.go
@@ -116,7 +116,7 @@ func providerInfo(provider string, ev *libhoney.Event) {
 			"BUILD_REPOSITORY_URI":                 "repo",
 		}
 
-	case "github-actions", "githubactions", "github":
+	case "github-actions", "githubactions", "github", "gha-buildevents":
 		envVars = map[string]string{
 			"GITHUB_REF":        "branch",
 			"GITHUB_RUN_ID":     "build_num",


### PR DESCRIPTION
We'd like to allow honeycombio/gha-buildevents to [differentiate itself](https://github.com/honeycombio/gha-buildevents/blob/v1.0.6/src/buildevents.ts#L28) from using `buildevents` manually inside GHA. Adds this new identifier to the GHA-related provider setup, so we still get these ENV variables set.