### PR TITLE
Removes warning when `dataset` is configured without setting `service-name`

### DIFF
--- a/cmd_root.go
+++ b/cmd_root.go
@@ -43,12 +43,7 @@ about your Continuous Integration builds.`,
 					cfg.Dataset = trimmed
 				} else {
 					// service_name was not specified
-					if cfg.Dataset != "" {
-						// dataset was, so use it but warn
-						if !quiet {
-							fmt.Fprintf(os.Stderr, "WARN: dataset is deprecated, please use service_name.\n")
-						}
-					} else {
+					if cfg.Dataset == "" {
 						// neither was specified, so just use the default
 						cfg.Dataset = "buildevents"
 					}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

As part of introducing Environments and Services, we also support users of Buildevents to configure the `service-name` associated to Build Events. However, for Build Events, the configuration `dataset` is also still valid to allow users to name the bucket into which events from their pipelines and builds are sent to. 

We are removing the "Warning" prompting users to change their dataset config to be called service name.

## Short description of the changes

* Remove the warning to change dataset to service name
* Ensure we are setting a default value if no dataset or service name is set (configured)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202842340194784