### PR TITLE
Include field `error` true for spans representing failure results

### DIFF
--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -99,6 +99,7 @@ will be launched via "bash -c" using "exec". The shell can be changed with the
 				ev.AddField("status", "success")
 			} else {
 				ev.Add(map[string]interface{}{
+					"error":          true,
 					"status":         "failure",
 					"failure_reason": err.Error(),
 				})


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We noticed for Github Actions or even CircleCI buildevents that the step or command that represents the failure does not include the boolean field error set to `true`

**We use this value to signal the error state in the UI:**

![Signaling which step(s) contains the error](https://user-images.githubusercontent.com/1179762/186550212-f2ba6893-453d-4a36-aaa0-bc37122f23a1.png)

**AND in the calculation to display error rates on the Home page for Buildevents:** 

![Home Page - Error rate](https://user-images.githubusercontent.com/1179762/186550170-7f2dbf56-dce9-4a4f-8399-3eeab9a8ddb0.png)


## Short description of the changes

Includes the field error true along with sending status failed and failure reason for a span

