### PR TITLE
Remove escaping of script input

### DIFF
--- a/cmd_cmd.go
+++ b/cmd_cmd.go
@@ -48,11 +48,7 @@ will be launched via "bash -c" using "exec". The shell can be changed with the
 			quiet, _ := cmd.Flags().GetBool("quiet")
 			shell, _ := cmd.Flags().GetString("shell")
 
-			var quoted []string
-			for _, s := range args[3:] {
-				quoted = append(quoted, fmt.Sprintf("\"%s\"", strings.Replace(s, "\"", "\\\"", -1)))
-			}
-			subcmd := strings.Join(quoted, " ")
+			subcmd := strings.Join(args[3:], " ")
 
 			ev := createEvent(cfg, *ciProvider, traceID)
 			defer ev.Send()


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

In `cmd` mode, anything after the `--` ends up given to `bash -c` as an input (when you don't customize the shell).

The problem is that there's some escaping done that modifies that breaks the input, and I believe the proper escaping of strings should be the responsibility of the end user. This becomes a bigger problem when you use `buildevents` as a shell wrapper with a Makefile, or a justfile.

Example of commands that don't work (and IMO should):

* `./buildevents cmd -k BLAH -p Gitlab-CI -d blah 123 123 build -- "echo blah"`: `echo blah: command not found`
* `./buildevents cmd -k BLAH -p Gitlab-CI -d blah 123 123 build -- 'if [ 2 -gt 100 ]; then echo "hi"; fi'`

## Short description of the changes

- Stop concatenating the script input as a single script and escaping quotes