### PR TITLE
chore: add maint: prefix to dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates https://github.com/honeycombio/telemetry-team/issues/389

## Short description of the changes

add `maint:` prefix to dependabot prs

## How to verify that this has the expected result

next dependabot should not fail rules because it should be prefixed with `maint:`