### PR TITLE
maint: transfer ownership to API team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/telemetry-team
+* @honeycombio/api-team


### PR DESCRIPTION
Transfers ownership of the project to the API Team
