### PR TITLE
Add os and arch to the meta.* data sent

### DIFF
--- a/common.go
+++ b/common.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +35,9 @@ func createEvent(cfg *libhoney.Config, provider string, traceID string) *libhone
 	}
 	ev.AddField("trace.trace_id", traceID)
 	ev.AddField("meta.version", Version)
+
+	ev.AddField("meta.os", runtime.GOOS)
+	ev.AddField("meta.arch", runtime.GOARCH)
 
 	return ev
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We live in a multiarch world now! I'm currently thinking about migrating a bunch of CI runners over from x86->arm64, and I can see a few uses for having machine architecture in my buildevents data.

1. What parts of my CI runs are on an x86 vs arm executor? What's been migrated, which spots are still to be done? (I expect this to be a gradual migration as various dependencies - mostly docker images - become available for arm.)

2. Performance improvements - can we compare run time of one arch versus another?

Both of these will be easily answered by buildevents data if these fields are present.

## Short description of the changes

Takes runtime.{GOOS,GOARCH}, and puts those values into `meta.os` and `meta.arch`. I believe performance impact will be negligible - both of these are constants set by the golang runtime on startup.