### PR TITLE
maint: update repo for pipeline team ownership

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,8 @@ Please see our [OSS process document](https://github.com/honeycombio/home/blob/m
 
 ## Which problem is this PR solving?
 
--
+- Closes #<enter issue here>
 
 ## Short description of the changes
 
--
-
+## How to verify that this has the expected result

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       interval: "monthly"
     labels:
       - "type: dependencies"
-    reviewers:
-      - "honeycombio/api-team"
     commit-message:
       prefix: "maint"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      examples:
+        patterns:
+          - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,8 @@ changelog:
     - title: 🛠 Maintenance
       labels:
         - "type: maintenance"
+        - "type: dependencies"
+        - "type: documentation"
     - title: 🤷 Other Changes
       labels:
         - "*"

--- a/.github/workflows/add-to-project-v2.yml
+++ b/.github/workflows/add-to-project-v2.yml
@@ -1,0 +1,15 @@
+name: Add to project
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    name: Add issues and PRs to project
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/honeycombio/projects/27
+          github-token: ${{ secrets.GHPROJECTS_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,16 @@
-# Creating a new release
+# Releasing
 
-1. Use [go-licenses](https://github.com/google/go-licenses) to ensure all project dependency licenses are correclty represented in this repository:
-  1. Install go-licenses (if not already installed) `go install github.com/google/go-licenses@latest`
-  2. Run and save licenses `go-licenses save github.com/honeycombio/buildevents --save_path="./LICENSES"`
-  3. If there are any changes, submit PR to update licenses.
-2. Prep update PR for the [orb](https://github.com/honeycombio/buildevents-orb) with the new version of buildevents.
-3. Add new entry in the CHANGELOG.
-4. Once the above change is merged into `main`, tag `main` with the new version, e.g. `v0.6.1`. Push the tags. This will kick off CI, which will create a draft GitHub release.
-5. Update release notes using the CHANGELOG entry on the new draft GitHub release, and publish it.
+- Use [go-licenses](https://github.com/google/go-licenses) to ensure all project dependency licenses are correctly represented in this repository:
+  - Install go-licenses (if not already installed) `go install github.com/google/go-licenses@latest`
+  - Run and save licenses `go-licenses save github.com/honeycombio/buildevents --save_path="./LICENSES"`
+  - If there are any changes, submit a separate PR to update licenses.
+- Prep update PR for the [orb](https://github.com/honeycombio/buildevents-orb) with the new version of buildevents.
+- Update `CHANGELOG.md` with the changes since the last release. Consider automating with a command such as these two:
+  - `git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline > new-in-this-release.log`
+  - `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
+- Commit changes, push, and open a release preparation pull request for review.
+- Once the pull request is merged, fetch the updated `main` branch.
+- Apply a tag for the new version on the merged commit (e.g. `git tag -a v2.3.1 -m "v2.3.1"`)
+- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v2.3.1`
+- Ensure that there is a draft GitHub release created as part of CI publish steps.
+- Click "generate release notes" in GitHub for full changelog notes and any new contributors.


### PR DESCRIPTION
## Which problem is this PR solving?

- finish handoff of repo to pipeline team

## Short description of the changes

- add github workflow for github project
- remove reviewers section with api-team 
  - removing reviewers altogether bc dependabot will just use CODEOWNERS file to assign
- group dependencies into 1 PR
- update PR template and release yml
- update releasing guide with more detail
