### PR TITLE
feat: add w3 trace context support to cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,10 @@ The event that arrives at Honeycomb might look like:
 
 ## Attaching more traces from your build and test process
 
-Every command running through `buildevents cmd` will receive a `HONEYCOMB_TRACE` environment variable that contains a marshalled trace propagation context. This can be used to connect more spans to this trace.
+Every command running through `buildevents cmd` will receive a `HONEYCOMB_TRACE` environment variable that contains a marshalled Honeycomb Beeline trace propagation context. This can be used to connect more spans to this trace.
+
+You may also use a W3 propagation context by passing the `--w3` flag to `buildevents cmd`. When this flag is set,
+every command will instead receive the `HONEYCOMB_W3_TRACEPARENT` and `HONEYCOMB_W3_TRACESTATE` environment variables.
 
 Ruby Beeline example:
 ```ruby


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #171 (possibly)

## Short description of the changes

Adds a `--w3` boolean flag to `cmd`. 

If this flag is set, instead of [outputting a marshalled beeline trace propagation context](https://github.com/honeycombio/buildevents?tab=readme-ov-file#attaching-more-traces-from-your-build-and-test-process) into the `HONEYCOMB_TRACE` environment variable, cmd` will output a [W3 trace context](https://docs.honeycomb.io/troubleshoot/product-lifecycle/recommended-migrations/migrate-from-beelines/go/#interoperability-with-opentelemetry) into the environment variables `HONEYCOMB_W3_TRACEPARENT` and `HONEYCOMB_W3_TRACESTATE`.

## How to verify that this has the expected result

Great question! I don't know how to test this