### PR TITLE
fix(watch): not_running is the new queued

### DIFF
--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -251,6 +251,8 @@ func evalWorkflow(client *circleci.Client, wfID string, jobName string) (anyRunn
 			// it's not configured to run this build (because of a tag or something)
 			anyBlocked = true
 			continue
+		case "not_running":
+			fallthrough
 		case "queued":
 			// queued means a job is due to start running soon, so we consider it running
 			// already.


### PR DESCRIPTION
## Which problem is this PR solving?

We are seeing premature buildevents terminations because we see all jobs succeeded or failed, and ignore the not_running.

## Short description of the changes

Treat the new not_running status the same as "queued".